### PR TITLE
Fix luajit's ffi.d.tl

### DIFF
--- a/types/luajit/ffi.d.tl
+++ b/types/luajit/ffi.d.tl
@@ -23,7 +23,8 @@ local record libffi
     copy:       function(CData, string)
     fill:       function(CData, integer, CData)
     abi:        function(string): boolean
-    set:        function(function)
+    os:         string
+    arch:       string
 
     C: CNamespace
 end


### PR DESCRIPTION
LuaJIT [ffi documentation](https://luajit.org/ext_ffi_api.html) defines two string attributes: `os` and `arch`, that were missing here.  Also there was no `ffi.set` function, I even searched in old 2.0 and 1.x luajit versions... I don't know where it came from.